### PR TITLE
fix: CLIN-1177 updated pn/an calculation

### DIFF
--- a/src/main/scala/bio/ferlab/clin/etl/utils/FrequencyUtils.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/utils/FrequencyUtils.scala
@@ -14,23 +14,24 @@ object FrequencyUtils {
   /**
    * allele count
    */
-  val ac: Column = sum(array_sum(filter(col("calls"), c => c === 1))) as "ac"
+  val ac: Column = sum(when(frequencyFilter, array_sum(filter(col("calls"), c => c === 1))).otherwise(0)) as "ac"
+
   /**
    * allele total number
    */
-  val an: Column = sum(lit(2)) as "an"
+  val an: Column = sum(size(col("calls"))) as "an"
 
   /**
    * participant count
    */
-  val pc: Column = sum(when(col("zygosity").isin("HOM", "HET"), 1).otherwise(0)) as "pc"
+  val pc: Column = sum(when(array_contains(col("calls"), 1) and frequencyFilter, 1).otherwise(0)) as "pc"
 
   /**
    * participant total number
    */
   val pn: Column = sum(lit(1)) as "pn"
 
-  val hom: Column = sum(when(col("zygosity") === "HOM", 1).otherwise(0)) as "hom"
-  val het: Column = sum(when(col("zygosity") === "HET", 1).otherwise(0)) as "het"
+  val hom: Column = sum(when(col("zygosity") === "HOM" and frequencyFilter, 1).otherwise(0)) as "hom"
+  val het: Column = sum(when(col("zygosity") === "HET" and frequencyFilter, 1).otherwise(0)) as "het"
 
 }

--- a/src/test/scala/bio/ferlab/clin/etl/utils/FrequencyUtilsSpec.scala
+++ b/src/test/scala/bio/ferlab/clin/etl/utils/FrequencyUtilsSpec.scala
@@ -2,21 +2,23 @@ package bio.ferlab.clin.etl.utils
 
 import bio.ferlab.clin.etl.utils.FrequencyUtils._
 import bio.ferlab.clin.testutils.WithSparkSession
+import org.apache.spark.sql.DataFrame
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class FrequencyUtilsSpec extends AnyFlatSpec with WithSparkSession with Matchers {
+  import spark.implicits._
+
+  val occurrences: DataFrame = Seq(
+    (Seq(0, 1)  , Array("PASS"), 10, 30),
+    (Seq(1, 1)  , Array("PASS"), 10, 30),
+    (Seq(0, 0)  , Array("PASS"), 10, 30),
+    (Seq(1, -1) , Array("PASS"), 10, 30),
+    (Seq(-1)    , Array("PASS"), 10, 30),
+    (Seq(0, 1)  , Array("PASS"), 10, 30),
+  ).toDF("calls", "filters", "ad_alt", "gq")
 
   "ac" should "return sum of allele count" in {
-    import spark.implicits._
-    val occurrences = Seq(
-      (Seq(0, 1)),
-      (Seq(1, 1)),
-      (Seq(0, 0)),
-      (Seq(1, -1)),
-      (Seq(-1, -1)),
-      (Seq(0, 1)),
-    ).toDF("calls")
     occurrences
       .select(
         ac
@@ -25,33 +27,14 @@ class FrequencyUtilsSpec extends AnyFlatSpec with WithSparkSession with Matchers
   }
 
   "an" should "return sum of allele numbers" in {
-    import spark.implicits._
-    val occurrences = Seq(
-      (Seq(0, 1)),
-      (Seq(1, 1)),
-      (Seq(0, 0)),
-      (Seq(1, -1)),
-      (Seq(-1, -1)),
-      (Seq(0, 1)),
-    ).toDF("calls")
     occurrences
       .select(
         FrequencyUtils.an
-      ).as[Long].collect() should contain only 12
+      ).as[Long].collect() should contain only 11
 
   }
 
   "pc" should "return number of patient with at least 1 alternate allele" in {
-    import spark.implicits._
-    val occurrences = Seq(
-      ("HET"),
-      ("HET"),
-      ("HOM REF"),
-      ("HOM"),
-      ("HOM"),
-      ("UNK"),
-    ).toDF("zygosity")
-
     occurrences
       .select(
         FrequencyUtils.pc
@@ -60,32 +43,23 @@ class FrequencyUtilsSpec extends AnyFlatSpec with WithSparkSession with Matchers
   }
 
   "pn" should "return number of patient with a pass filter" in {
-    import spark.implicits._
-    val occurrences = Seq(
-      ("HET"),
-      ("HET"),
-      ("HOM REF"),
-      ("HOM"),
-      ("HOM"),
-      ("UNK"),
-    ).toDF("zygosity")
-
     occurrences
       .select(
         FrequencyUtils.pn
       ).as[Long].collect() should contain only 6
 
   }
+
   "hom" should "return number of patients with homozygotes alternate alleles" in {
     import spark.implicits._
-    val occurrences = Seq(
-      ("HET"),
-      ("HOM REF"),
-      ("HOM"),
-      ("HOM"),
-      ("UNK")
-    ).toDF("zygosity")
-    occurrences
+    Seq(
+      ("HET"    , Array("PASS"), 10, 30),
+      ("HOM REF", Array("PASS"), 10, 30),
+      ("HOM"    , Array("PASS"), 10, 30),
+      ("HOM"    , Array("PASS"), 10, 30),
+      ("UNK"    , Array("PASS"), 10, 30)
+    )
+      .toDF("zygosity", "filters", "ad_alt", "gq")
       .select(
         hom
       ).as[Long].collect() should contain only 2

--- a/src/test/scala/bio/ferlab/clin/etl/vcf/VariantsSpec.scala
+++ b/src/test/scala/bio/ferlab/clin/etl/vcf/VariantsSpec.scala
@@ -117,7 +117,7 @@ class VariantsSpec extends AnyFlatSpec with WithSparkSession with Matchers with 
         referenceAllele = "A",
         INFO_FILTERS = List("DRAGENHardQUAL;LowDepth"), //Should not be included in frequencies
         `genotypes` = List(
-          GENOTYPES(`sampleId` = "1", `calls` = List(1, 1)),
+          GENOTYPES(`sampleId` = "1", `calls` = List(1, 1), `alleleDepths` = List(0, 30)),
         ))
     ).toDF(),
     clinical_impression.id -> clinicalImpressionsDf,
@@ -137,22 +137,20 @@ class VariantsSpec extends AnyFlatSpec with WithSparkSession with Matchers with 
       `frequency_RQDM` = AnalysisFrequencies(Frequency(2, 4, 0.5, 1, 2, 0.5, 1), Frequency(1, 4, 0.25, 1, 2, 0.5, 0), Frequency(3, 8, 0.375, 2, 4, 0.5, 1)),
       `created_on` = null)
     )
-    val emptyFrequency = Frequency(0, 0, 0, 0, 0, 0, 0)
-    val emptyFrequencies = AnalysisFrequencies(emptyFrequency, emptyFrequency, emptyFrequency)
 
     val variantWithoutFreqG = result.find(_.`reference` == "G")
     variantWithoutFreqG.map(_.copy(`created_on` = null)) shouldBe Some(NormalizedVariants(
       reference= "G",
-      `frequencies_by_analysis` = List.empty[AnalysisCodeFrequencies],
-      `frequency_RQDM` = emptyFrequencies,
+      `frequencies_by_analysis` = List(AnalysisCodeFrequencies("MMG", "Maladies musculaires (Panel global)",Frequency(0,4,0.0,0,2,0.0,0),Frequency(0,0,0.0,0,0,0.0,0),Frequency(0,4,0.0,0,2,0.0,0))),
+      `frequency_RQDM` = AnalysisFrequencies(Frequency(0,4,0.0,0,2,0.0,0), Frequency(0, 0, 0, 0, 0, 0, 0), Frequency(0,4,0.0,0,2,0.0,0)),
       `created_on` = null)
     )
 
     val variantWithoutFreqA = result.find(_.`reference` == "A")
     variantWithoutFreqA.map(_.copy(`created_on` = null)) shouldBe Some(NormalizedVariants(
       reference= "A",
-      `frequencies_by_analysis` = List.empty[AnalysisCodeFrequencies],
-      `frequency_RQDM` = emptyFrequencies,
+      `frequencies_by_analysis` = List(AnalysisCodeFrequencies("MMG","Maladies musculaires (Panel global)",Frequency(0,2,0.0,0,1,0.0,0),Frequency(0,0,0.0,0,0,0.0,0),Frequency(0,2,0.0,0,1,0.0,0))),
+      `frequency_RQDM` = AnalysisFrequencies(Frequency(0,2,0.0,0,1,0.0,0),Frequency(0,0,0.0,0,0,0.0,0),Frequency(0,2,0.0,0,1,0.0,0)),
       `created_on` = null)
     )
 


### PR DESCRIPTION
The goal of this change is to not filter out any patient for the an and pn computation. ie, if the batch is 128 people, pn should be 128 and an 256 for every variants.
solution: move the filter `frequencyFilter` from `getVariantsForFrequency` to ac, pc, hom and het computation.