### PR TITLE
fix: CLIN-1521 Error in ColumnsContainSameValueVariantCentric

### DIFF
--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric.scala
@@ -104,8 +104,7 @@ object ColumnsContainSameValueVariantCentric extends TestingApp {
         variant_centric.select(explode($"varsome.acmg.classifications")).select("col.*").columns.filterNot(List("met_criteria").contains(_)): _*
       ),
       shouldNotContainSameValue(
-        variant_centric.select(explode($"consequences")).select("col.*"),
-        variant_centric.select(explode($"consequences")).select("col.*").columns.filterNot(List("feature_type").contains(_)): _*
+        variant_centric.select(explode($"consequences")).select("col.*").drop(col("feature_type"))
       ),
       shouldNotContainSameValue(
         variant_centric.select(explode($"consequences")).select("col.predictions.*")


### PR DESCRIPTION
Tentative de contournement pour solutionner l'erreur suivante dans le DataTest same_value_variant_centric:
`Exception in thread "main" org.apache.spark.sql.AnalysisException: Column 'chromosome' does not exist. Did you mean one of the following? [chromosome, codons, biotype, canonical, hgvsc, hgvsp, symbol, aa_change, alternate, cds_position, exon, impact_score, intron, reference, strand, uniprot_id, amino_acids, cdna_position, consequences, conservations, mane_plus, mane_select, predictions, start, symbol_id_1, vep_impact, feature_type, ensembl_gene_id, protein_position, refseq_mrna_id, coding_dna_change, ensembl_feature_id, ensembl_transcript_id];`