### PR TITLE
feat: CLIN-1686 - add CNV hash

### DIFF
--- a/src/main/scala/bio/ferlab/clin/etl/enriched/CNV.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/enriched/CNV.scala
@@ -47,6 +47,7 @@ class CNV()(implicit configuration: Configuration) extends ETLSingleDestination 
       .agg(first($"cnv") as "cnv", collect_list($"gene") as "genes")
       .select($"cnv.*", $"genes")
       .withColumn("number_genes", size($"genes"))
+      .withColumn("hash", sha1(concat_ws("-", col("name"), col("aliquot_id"))))
     groupedCnv
   }
 

--- a/src/test/scala/bio/ferlab/clin/model/CnvEnrichedOutput.scala
+++ b/src/test/scala/bio/ferlab/clin/model/CnvEnrichedOutput.scala
@@ -50,7 +50,8 @@ case class CnvEnrichedOutput(`aliquot_id`: String = "11111",
                              `specimen_id`: String = "SP_001",
                              `sample_id`: String = "SA_001",
                              `genes`: List[ENRICHED_CNV_GENES] = List(ENRICHED_CNV_GENES()),
-                             `number_genes`: Int = 1)
+                             `number_genes`: Int = 1,
+                             `hash`: String = "e9458a88f3281d40be3d71cad7ac44d90b15b2cb")
 
 case class ENRICHED_CNV_GENES(`symbol`: Option[String] = Some("OR4F5"),
                  `refseq_id`: Option[String] = Some("NC_000001.11"),


### PR DESCRIPTION
- add `hash` field in CNV centric based on `{name}-{aliquot_id}`
- ES template already have a `hash` field (for some reasons...)