### PR TITLE
feat: CLIN-1776  - genes should be empty

### DIFF
--- a/src/main/scala/bio/ferlab/clin/etl/enriched/CNV.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/enriched/CNV.scala
@@ -41,8 +41,8 @@ class CNV()(implicit configuration: Configuration) extends ETLSingleDestination 
     val groupedCnv = joinedWithExons
       .select(struct($"cnv.*") as "cnv", struct($"refseq_genes.gene" as "symbol", $"refseq_genes.refseq_id" as "refseq_id", $"gene_length", $"overlap_bases", $"overlap_cnv_ratio", $"overlap_gene_ratio", $"panels") as "gene")
       .groupBy($"cnv.chromosome", $"cnv.start", $"cnv.reference", $"cnv.alternate", $"cnv.aliquot_id", $"gene.symbol")
-      .agg(first($"cnv") as "cnv", first($"gene") as "gene", count(lit(1)) as "overlap_exons")
-      .select($"cnv", struct($"gene.*", $"overlap_exons") as "gene")
+      .agg(first($"cnv") as "cnv", when($"gene.symbol".isNotNull, first($"gene")).otherwise(null) as "gene", count(lit(1) )as "overlap_exons")
+      .select($"cnv", when($"gene".isNotNull, struct($"gene.*", $"overlap_exons")).otherwise(null) as "gene")
       .groupBy($"cnv.chromosome", $"cnv.start", $"cnv.reference", $"cnv.alternate", $"cnv.aliquot_id")
       .agg(first($"cnv") as "cnv", collect_list($"gene") as "genes")
       .select($"cnv.*", $"genes")


### PR DESCRIPTION
Index des CNVs, le array `genes` contient toujours au moins 1 element alors qu'il devrait etre vide si aucun genes.

Avant:
|genes|number_genes|
|-|-|
|[{null,null,...,overlap_exons = 1}]|1|

Apres
|genes|number_genes|
|-|-|
|[]|0|

A titre informatif cela ressemblait a ca dans ES
```
"genes": [
  {
   "overlap_exons": 1
  }
],
"number_genes": 1,
```
