### PR TITLE
fix: CLIN-1876

### DIFF
--- a/src/main/scala/bio/ferlab/clin/etl/enriched/Consequences.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/enriched/Consequences.scala
@@ -79,6 +79,7 @@ class Consequences()(implicit configuration: Configuration) extends ETLSingleDes
     import spark.implicits._
     val dbnsfpRenamed =
       dbnsfp
+        .filter($"aaref".isNotNull)
         .withColumn("start", col("start").cast(LongType))
         .selectLocus(
           $"ensembl_transcript_id" as "ensembl_feature_id",


### PR DESCRIPTION
Filtering `aaref` not null will remove all the duplicates from the `groupBy($"chromosome", $"start", $"reference", $"alternate", $"ensembl_transcript_id").count`

Count of aaref NULL = 6825114
Count of aaref NOT NULL = 232284130