### PR TITLE
fix: CLIN-1884 - variants mapping

### DIFF
--- a/src/main/resources/templates/variant_centric_template.json
+++ b/src/main/resources/templates/variant_centric_template.json
@@ -132,7 +132,7 @@
             "intron": {
               "properties": {
                 "rank": {
-                  "type": "long"
+                  "type": "keyword"
                 },
                 "total": {
                   "type": "long"


### PR DESCRIPTION
Trying to put some value like that in PROD and ES complains about expecting a long. We don't use that field in the front-end and another field named `exon.rank` was already keyword, this change seems ok to me.

```
            "intron": {
                "rank": "2-3",
                "total": "3"
            },
```