### PR TITLE
feat: CLIN-2070 - cleanup somatic freqs

### DIFF
--- a/src/main/scala/bio/ferlab/clin/etl/normalized/Variants.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/normalized/Variants.scala
@@ -2,6 +2,7 @@ package bio.ferlab.clin.etl.normalized
 
 import bio.ferlab.clin.etl.utils.FrequencyUtils
 import bio.ferlab.clin.etl.normalized.Occurrences.getDiseaseStatus
+import bio.ferlab.clin.etl.utils.FrequencyUtils.{emptyFrequencies, emptyFrequency, emptyFrequencyRQDM}
 import bio.ferlab.datalake.commons.config.{Configuration, DatasetConf, RepartitionByColumns}
 import bio.ferlab.datalake.spark3.etl.ETLSingleDestination
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
@@ -112,31 +113,6 @@ class Variants(batchId: String)(implicit configuration: Configuration) extends E
       .drop("genotype")
       .join(broadcast(clinicalInfos), Seq("aliquot_id"))
   }
-
-  val emptyFrequency =
-    struct(
-      lit(0L) as "ac",
-      lit(0L) as "an",
-      lit(0.0) as "af",
-      lit(0L) as "pc",
-      lit(0L) as "pn",
-      lit(0.0) as "pf",
-      lit(0L) as "hom"
-    )
-
-  val emptyFrequencyRQDM = struct(
-    emptyFrequency as "affected",
-    emptyFrequency as "non_affected",
-    emptyFrequency as "total"
-  )
-
-  val emptyFrequencies = struct(
-    lit("") as "analysis_display_name",
-    lit("") as "analysis_code",
-    emptyFrequency as "affected",
-    emptyFrequency as "non_affected",
-    emptyFrequency as "total"
-  )
 
   def getVariantsEmptyFrequencies(variants: DataFrame): DataFrame = {
     variants

--- a/src/main/scala/bio/ferlab/clin/etl/utils/FrequencyUtils.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/utils/FrequencyUtils.scala
@@ -32,4 +32,29 @@ object FrequencyUtils {
   val hom: Column = sum(when(col("zygosity") === "HOM" and frequencyFilter, 1).otherwise(0)) as "hom"
   val het: Column = sum(when(col("zygosity") === "HET" and frequencyFilter, 1).otherwise(0)) as "het"
 
+  val emptyFrequency =
+    struct(
+      lit(0L) as "ac",
+      lit(0L) as "an",
+      lit(0.0) as "af",
+      lit(0L) as "pc",
+      lit(0L) as "pn",
+      lit(0.0) as "pf",
+      lit(0L) as "hom"
+    )
+
+  val emptyFrequencyRQDM = struct(
+    emptyFrequency as "affected",
+    emptyFrequency as "non_affected",
+    emptyFrequency as "total"
+  )
+
+  val emptyFrequencies = struct(
+    lit("") as "analysis_display_name",
+    lit("") as "analysis_code",
+    emptyFrequency as "affected",
+    emptyFrequency as "non_affected",
+    emptyFrequency as "total"
+  )
+
 }


### PR DESCRIPTION
Feature pour nettoyer les frequences Somatic

- [x] mettre `frequencies_by_analysis` vide si somatic
- [x] mettre `frequency_RQDM` tout a 0 si somatic
- [x] ne pas toucher aux frequences si le variant est germline + somatic
- [x] unit tests
- [x] test QA (avant merger)

**Avant**
![Screenshot from 2023-08-03 18-10-02](https://github.com/Ferlab-Ste-Justine/clin-variant-etl/assets/35352649/5e050ba5-7b84-416a-864a-ffa480883892)

**Apres**
![Screenshot from 2023-08-03 18-09-06](https://github.com/Ferlab-Ste-Justine/clin-variant-etl/assets/35352649/0c362b49-1fa5-44cb-9241-e697af8c6d37)
