### PR TITLE
fix: CLIN-2246 - coverageByGene hash with chr

### DIFF
--- a/src/main/scala/bio/ferlab/clin/etl/enriched/CoverageByGene.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/enriched/CoverageByGene.scala
@@ -67,7 +67,7 @@ object CoverageByGene {
       .select(joinedWithGenes("*"), panels("panels"))
 
     val withHash = joinedWithPanels
-      .withColumn("hash", sha1(concat_ws("-", col("batch_id"), col("aliquot_id"), col("gene"))))
+      .withColumn("hash", sha1(concat_ws("-", col("batch_id"), col("aliquot_id"), col("gene"), col("chromosome"))))
 
     withHash
   }

--- a/src/main/scala/bio/ferlab/clin/etl/enriched/CoverageByGene.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/enriched/CoverageByGene.scala
@@ -54,7 +54,7 @@ object CoverageByGene {
 
     val refseqGenesWithoutChrY = refseqGenes
       .orderBy(col("gene"), col("chromosome")) // chr X entries first
-      .dropDuplicates(Seq("gene"))
+      .dropDuplicates("gene")
 
     val joinWithAnnotation = coverage
       .join(refseqGenesWithoutChrY, Seq("gene"), "left")

--- a/src/main/scala/bio/ferlab/clin/etl/enriched/CoverageByGene.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/enriched/CoverageByGene.scala
@@ -52,8 +52,12 @@ object CoverageByGene {
 
     val refseqGenes = refseq.filter(col("type") === "gene")
 
+    val refseqGenesWithoutChrY = refseqGenes
+      .orderBy(col("gene"), col("chromosome")) // chr X entries first
+      .dropDuplicates(Seq("gene"))
+
     val joinWithAnnotation = coverage
-      .join(refseqGenes, Seq("gene"), "left")
+      .join(refseqGenesWithoutChrY, Seq("gene"), "left")
       .select(coverage("*"), refseq("start"), refseq("end"), refseq("chromosome"))
       .withColumn("start", col("start").cast(LongType))
       .withColumn("end", col("end").cast(LongType))

--- a/src/test/scala/bio/ferlab/clin/etl/enriched/CoverageByGeneSpec.scala
+++ b/src/test/scala/bio/ferlab/clin/etl/enriched/CoverageByGeneSpec.scala
@@ -28,7 +28,8 @@ class CoverageByGeneSpec extends SparkSpec with WithTestConfig {
     ).toDF()
 
     val refseqDf = Seq(
-      NormalizedRefSeq(gene = "OR4F5", start = "10000", end = "10059", chromosome = "12", `type` = "gene"),
+      NormalizedRefSeq(gene = "OR4F5", start = "10000", end = "10059", chromosome = "Y", `type` = "gene"),
+      NormalizedRefSeq(gene = "OR4F5", start = "10000", end = "10059", chromosome = "X", `type` = "gene"),
       NormalizedRefSeq(gene = "OR4F5", start = "10000", end = "10059", chromosome = "12", `type` = "exon")
     ).toDF()
 
@@ -61,7 +62,7 @@ class CoverageByGeneSpec extends SparkSpec with WithTestConfig {
         size = 1,
         coverage5 = 0.3f, coverage15 = 0.52f, coverage30 = 0.52f, coverage50 = 2.5f, coverage100 = 12.3f, coverage200 = 1.23f,
         coverage300 = 1.232f, coverage400 = 3.02f, coverage500 = 1.2f, coverage1000 = 8.4f, aliquot_id = "aliquot1", batch_id = "test_extum",
-        chromosome = "12", panels =  Seq("DYSTM", "MITN"), omim_gene_id = "1234", service_request_id = "SR0095",
+        chromosome = "X", panels =  Seq("DYSTM", "MITN"), omim_gene_id = "1234", service_request_id = "SR0095",
         ensembl_gene_id = "EBS123414", start = 10000, end = 10059
     ,
     ),

--- a/src/test/scala/bio/ferlab/clin/model/CoverageByGeneCentricOutput.scala
+++ b/src/test/scala/bio/ferlab/clin/model/CoverageByGeneCentricOutput.scala
@@ -29,5 +29,5 @@ case class CoverageByGeneCentricOutput(`gene`: String = "A1BG",
                                   `ensembl_gene_id`: String = "ENS1230912",
                                   `omim_gene_id`: String = "365432",
                                   `panels`: Seq[String] = Seq("DYSTM", "MITN"),
-                                  `hash`: String = "bb299edc1d67ea7f7ae0f0d649aeb29558b3a967"
+                                  `hash`: String = "0100ad84901f6552c8269267da966037622c14f8"
                                  )

--- a/src/test/scala/bio/ferlab/clin/model/CoverageByGeneCentricOutput.scala
+++ b/src/test/scala/bio/ferlab/clin/model/CoverageByGeneCentricOutput.scala
@@ -29,5 +29,5 @@ case class CoverageByGeneCentricOutput(`gene`: String = "A1BG",
                                   `ensembl_gene_id`: String = "ENS1230912",
                                   `omim_gene_id`: String = "365432",
                                   `panels`: Seq[String] = Seq("DYSTM", "MITN"),
-                                  `hash`: String = "f0f5be6ab4e10640235ca5529401ade728c94736"
+                                  `hash`: String = "bb299edc1d67ea7f7ae0f0d649aeb29558b3a967"
                                  )

--- a/src/test/scala/bio/ferlab/clin/model/enriched/EnrichedCoverageByGene.scala
+++ b/src/test/scala/bio/ferlab/clin/model/enriched/EnrichedCoverageByGene.scala
@@ -29,5 +29,5 @@ case class EnrichedCoverageByGene(`gene`: String = "A1BG",
                                   `ensembl_gene_id`: String = "ENS1230912",
                                   `omim_gene_id`: String = "365432",
                                   `panels`: Seq[String] = Seq("DYSTM", "MITN"),
-                                  `hash`: String = "f0f5be6ab4e10640235ca5529401ade728c94736"
+                                  `hash`: String = "bb299edc1d67ea7f7ae0f0d649aeb29558b3a967"
                                  )

--- a/src/test/scala/bio/ferlab/clin/model/enriched/EnrichedCoverageByGene.scala
+++ b/src/test/scala/bio/ferlab/clin/model/enriched/EnrichedCoverageByGene.scala
@@ -29,5 +29,5 @@ case class EnrichedCoverageByGene(`gene`: String = "A1BG",
                                   `ensembl_gene_id`: String = "ENS1230912",
                                   `omim_gene_id`: String = "365432",
                                   `panels`: Seq[String] = Seq("DYSTM", "MITN"),
-                                  `hash`: String = "bb299edc1d67ea7f7ae0f0d649aeb29558b3a967"
+                                  `hash`: String = "0100ad84901f6552c8269267da966037622c14f8"
                                  )


### PR DESCRIPTION
gene like `DHRSX` can be on both X and Y chr when doing the join with `ref_seq` hash needs an update