### PR TITLE
feat: CLIN-2853 Add and adjust etl_qa and etl_qc tests

### DIFF
--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainNoNullCoverageByGene.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainNoNullCoverageByGene.scala
@@ -4,14 +4,14 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainNoNullCoverageByGene extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
-      shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+      shouldNotContainNull(
+        coverage_by_gene,
+        "gene", "aliquot_id", "batch_id"
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainNoNullVariantCentric_Donors.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainNoNullVariantCentric_Donors.scala
@@ -4,14 +4,14 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainNoNullVariantCentric_Donors extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
-      shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+      shouldNotContainNull(
+        variant_centric.select(explode($"donors")).select("col.*"),
+        "patient_id", "aliquot_id", "batch_id", "service_request_id", "organization_id"
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainNoNullVariantCentric_FreqByAnal.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainNoNullVariantCentric_FreqByAnal.scala
@@ -4,14 +4,13 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainNoNullVariantCentric extends TestingApp {
+object ColumnsContainNoNullVariantCentric_FreqByAnal extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
       shouldNotContainNull(
-        variant_centric,
-        "chromosome", "start", "reference", "alternate"
+        variant_centric.select(explode($"frequencies_by_analysis") as "frequencies_by_analysis").select($"frequencies_by_analysis.analysis_code" as "analysis_code")
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainNoNullVariantCentric_FreqRQDM.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainNoNullVariantCentric_FreqRQDM.scala
@@ -4,14 +4,14 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainNoNullVariantCentric_FreqRQDM extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
-      shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+      shouldNotContainNull(
+        variant_centric.select($"frequency_RQDM.*"),
+        "affected", "non_affected", "total"
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullCoverageByGene.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullCoverageByGene.scala
@@ -4,14 +4,13 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainOnlyNullCoverageByGene extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
-      shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+      shouldNotContainOnlyNull(
+        coverage_by_gene
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_CMC.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_CMC.scala
@@ -4,14 +4,13 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainOnlyNullVariantCentric_CMC extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
-      shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+      shouldNotContainOnlyNull(
+        variant_centric.select($"cmc.*")
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_Clinvar.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_Clinvar.scala
@@ -4,14 +4,13 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainOnlyNullVariantCentric_Clinvar extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
-      shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+      shouldNotContainOnlyNull(
+        variant_centric.select($"clinvar.*")
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_Consequences.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_Consequences.scala
@@ -4,13 +4,16 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainOnlyNullVariantCentric extends TestingApp {
+object ColumnsContainOnlyNullVariantCentric_Consequences extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
       shouldNotContainOnlyNull(
-        variant_centric
+        variant_centric.select(explode($"consequences")).select("col.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"consequences")).select("col.predictions.*")
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_Donors.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_Donors.scala
@@ -1,0 +1,30 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainOnlyNullVariantCentric_Donors extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"donors")).select("col.*"),
+        variant_centric.select(explode($"donors")).select("col.*").columns.filterNot(List("analysis_display_name"/*CLIN-1358*/, "practitioner_role_id").contains(_)): _*
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"donors")).select(explode($"col.hc_complement")).select("col.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"donors")).select(explode($"col.possibly_hc_complement")).select("col.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"donors")).select($"col.exomiser.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"donors")).select($"col.exomiser_other_moi.*")
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_ExoMax.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_ExoMax.scala
@@ -4,14 +4,13 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainOnlyNullVariantCentric_ExoMax extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
-      shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+      shouldNotContainOnlyNull(
+        variant_centric.select($"exomiser_max.*")
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_ExtFreq.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_ExtFreq.scala
@@ -1,0 +1,35 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainOnlyNullVariantCentric_ExtFreq extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainOnlyNull(
+        variant_centric.select($"external_frequencies.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select($"external_frequencies.thousand_genomes.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select($"external_frequencies.topmed_bravo.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select($"external_frequencies.gnomad_genomes_2_1_1.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select($"external_frequencies.gnomad_exomes_2_1_1.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select($"external_frequencies.gnomad_genomes_3_0.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select($"external_frequencies.gnomad_genomes_3_1_1.*")
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_FraMax.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_FraMax.scala
@@ -4,14 +4,13 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainOnlyNullVariantCentric_FraMax extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
-      shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+      shouldNotContainOnlyNull(
+        variant_centric.select($"franklin_max.*")
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_FreqByAnal.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_FreqByAnal.scala
@@ -1,0 +1,27 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainOnlyNullVariantCentric_FreqByAnal extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"frequencies_by_analysis")).select("col.*"),
+        variant_centric.select(explode($"frequencies_by_analysis")).select("col.*").columns.filterNot(List("analysis_display_name"/*CLIN-1358*/).contains(_)): _*
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"frequencies_by_analysis")).select("col.affected.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"frequencies_by_analysis")).select("col.non_affected.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"frequencies_by_analysis")).select("col.total.*")
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_FreqRQDM.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_FreqRQDM.scala
@@ -1,0 +1,26 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainOnlyNullVariantCentric_FreqRQDM extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainOnlyNull(
+        variant_centric.select($"frequency_RQDM.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select($"frequency_RQDM.affected.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select($"frequency_RQDM.non_affected.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select($"frequency_RQDM.total.*")
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_Genes.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_Genes.scala
@@ -1,0 +1,32 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainOnlyNullVariantCentric_Genes extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"genes")).select("col.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"genes")).select(explode($"col.orphanet")).select("col.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"genes")).select(explode($"col.hpo")).select("col.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"genes")).select(explode($"col.omim")).select("col.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"genes")).select($"col.gnomad.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select(explode($"genes")).select($"col.spliceai.*")
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueCoverageByGene.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueCoverageByGene.scala
@@ -4,14 +4,13 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainSameValueCoverageByGene extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
       shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+        coverage_by_gene
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_CMC.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_CMC.scala
@@ -4,14 +4,13 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainSameValueVariantCentric_CMC extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
       shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+        variant_centric.select($"cmc.*")
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_Clinvar.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_Clinvar.scala
@@ -4,14 +4,13 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainSameValueVariantCentric_Clinvar extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
       shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+        variant_centric.select($"clinvar.*")
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_Consequences.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_Consequences.scala
@@ -1,0 +1,21 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainSameValueVariantCentric_Consequences extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"consequences")).select("col.*"),
+        variant_centric.select(explode($"consequences")).select("col.*").columns.filterNot(List("feature_type", "picked").contains(_)): _*
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"consequences")).select("col.predictions.*")
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_Donors.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_Donors.scala
@@ -1,0 +1,30 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainSameValueVariantCentric_Donors extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"donors")).select("col.*"),
+        variant_centric.select(explode($"donors")).select("col.*").columns.filterNot(List("has_alt", "last_update", "variant_type", "sequencing_strategy", "genome_build").contains(_)): _*
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"donors")).select(explode($"col.hc_complement")).select("col.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"donors")).select(explode($"col.possibly_hc_complement")).select("col.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"donors")).select($"col.exomiser.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"donors")).select($"col.exomiser_other_moi.*")
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_ExoMax.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_ExoMax.scala
@@ -4,14 +4,13 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainSameValueVariantCentric_ExoMax extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
       shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+        variant_centric.select($"exomiser_max.*")
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_ExtFreq.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_ExtFreq.scala
@@ -1,0 +1,36 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainSameValueVariantCentric_ExtFreq extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainSameValue(
+        variant_centric.select($"external_frequencies.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select($"external_frequencies.thousand_genomes.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select($"external_frequencies.topmed_bravo.*"),
+        variant_centric.select($"external_frequencies.topmed_bravo.*").columns.filterNot(List("an").contains(_)): _*
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select($"external_frequencies.gnomad_genomes_2_1_1.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select($"external_frequencies.gnomad_exomes_2_1_1.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select($"external_frequencies.gnomad_genomes_3_0.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select($"external_frequencies.gnomad_genomes_3_1_1.*")
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_FraMax.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_FraMax.scala
@@ -4,14 +4,13 @@ import bio.ferlab.clin.etl.qc.TestingApp
 import bio.ferlab.clin.etl.qc.TestingApp._
 import org.apache.spark.sql.functions._
 
-object ColumnsContainSameValueVariantCentric extends TestingApp {
+object ColumnsContainSameValueVariantCentric_FraMax extends TestingApp {
   run { spark =>
     import spark.implicits._
 
     handleErrors(
       shouldNotContainSameValue(
-        variant_centric,
-        variant_centric.columns.filterNot(List("variant_type", "assembly_version", "last_annotation_update").contains(_)): _*
+        variant_centric.select($"franklin_max.*")
       ),
     )
   }

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_FreqByAnal.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_FreqByAnal.scala
@@ -1,0 +1,26 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainSameValueVariantCentric_FreqByAnal extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"frequencies_by_analysis")).select("col.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"frequencies_by_analysis")).select("col.affected.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"frequencies_by_analysis")).select("col.non_affected.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"frequencies_by_analysis")).select("col.total.*")
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_FreqRQDM.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_FreqRQDM.scala
@@ -1,0 +1,29 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainSameValueVariantCentric_FreqRQDM extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainSameValue(
+        variant_centric.select($"frequency_RQDM.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select($"frequency_RQDM.affected.*"),
+        variant_centric.select($"frequency_RQDM.affected.*").columns.filterNot(List("an", "pn").contains(_)): _*
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select($"frequency_RQDM.non_affected.*"),
+        variant_centric.select($"frequency_RQDM.non_affected.*").columns.filterNot(List("an", "pn").contains(_)): _*
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select($"frequency_RQDM.total.*"),
+        variant_centric.select($"frequency_RQDM.total.*").columns.filterNot(List("an", "pn").contains(_)): _*
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_Genes.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_Genes.scala
@@ -1,0 +1,32 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainSameValueVariantCentric_Genes extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"genes")).select("col.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"genes")).select(explode($"col.orphanet")).select("col.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"genes")).select(explode($"col.hpo")).select("col.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"genes")).select(explode($"col.omim")).select("col.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"genes")).select($"col.gnomad.*")
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select(explode($"genes")).select($"col.spliceai.*")
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/variantlist/NonDuplicationCoverageByGeneCentric.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/variantlist/NonDuplicationCoverageByGeneCentric.scala
@@ -1,0 +1,18 @@
+package bio.ferlab.clin.etl.qc.variantlist
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+
+object NonDuplicationCoverageByGene extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldBeEmpty(
+        coverage_by_gene
+          .groupBy($"gene", $"aliquot_id", $"batch_id").count
+          .filter($"count" > 1)
+      )
+    )
+  }
+}


### PR DESCRIPTION
Add
- NonDuplicationCoverageByGene
- ColumnsContainNoNullCoverageByGene
- ColumnsContainNoNullVariantCentric_FreqRQDM
- ColumnsContainOnlyNullCoverageByGene
- ColumnsContainOnlyNullVariantCentric_ExoMax
- ColumnsContainOnlyNullVariantCentric_FraMax
- ColumnsContainSameValueCoverageByGene
- ColumnsContainSameValueVariantCentric_ExoMax
- ColumnsContainSameValueVariantCentric_FraMax

Split ColumnsContainNoNullVariantCentric
- ColumnsContainNoNullVariantCentric
- ColumnsContainNoNullVariantCentric_Donors
- ColumnsContainNoNullVariantCentric_FreqByAnal

Split ColumnsContainOnlyNullVariantCentric
- ColumnsContainOnlyNullVariantCentric
- ColumnsContainOnlyNullVariantCentric_Clinvar
- ColumnsContainOnlyNullVariantCentric_CMC
- ColumnsContainOnlyNullVariantCentric_Consequences
- ColumnsContainOnlyNullVariantCentric_Donors
- ColumnsContainOnlyNullVariantCentric_ExtFreq
- ColumnsContainOnlyNullVariantCentric_FreqByAnal
- ColumnsContainOnlyNullVariantCentric_FreqRQDM
- ColumnsContainOnlyNullVariantCentric_Genes

Split ColumnsContainSameValueVariantCentric
- ColumnsContainSameValueVariantCentric
- ColumnsContainSameValueVariantCentric_Clinvar
- ColumnsContainSameValueVariantCentric_CMC
- ColumnsContainSameValueVariantCentric_Consequences
- ColumnsContainSameValueVariantCentric_Donors
- ColumnsContainSameValueVariantCentric_ExtFreq
- ColumnsContainSameValueVariantCentric_FreqByAnal
- ColumnsContainSameValueVariantCentric_FreqRQDM
- ColumnsContainSameValueVariantCentric_Genes