### PR TITLE
feat: CLIN-2938 Add freq RQDM tumor DataTests

### DIFF
--- a/src/main/scala/bio/ferlab/clin/etl/qc/TestingApp.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/TestingApp.scala
@@ -148,8 +148,10 @@ object TestingApp {
   def array_sum(c: Column): Column = aggregate(c, lit(0), (accumulator, item) => accumulator + item)
   val includeFilter: Column = col("ad_alt") >= 3 && col("alternate") =!= "*"
   val frequencyFilter: Column = array_contains(col("filters"), "PASS") && includeFilter && col("gq") >= 20
+  val frequencyFilter_somatic: Column = array_contains(col("filters"), "PASS") && includeFilter && col("sq") >= 30
   val ac: Column = sum(when(frequencyFilter, array_sum(filter(col("calls"), c => c === 1))).otherwise(0)) as "expected_ac"
   val pc: Column = sum(when(array_contains(col("calls"), 1) and frequencyFilter, 1).otherwise(0)) as "expected_pc"
+  val pc_somatic: Column = sum(when(array_contains(col("calls"), 1) and frequencyFilter_somatic, 1).otherwise(0)) as "expected_pc"
 
   def combineErrors(errors: Option[String]*): Option[String] = {
     val filteredErrors = errors.flatten

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_FreqRQDMTumor.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainOnlyNullVariantCentric_FreqRQDMTumor.scala
@@ -1,0 +1,20 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainOnlyNullVariantCentric_FreqRQDMTumor extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainOnlyNull(
+        variant_centric.select($"freq_rqdm_tumor_only.*")
+      ),
+      shouldNotContainOnlyNull(
+        variant_centric.select($"freq_rqdm_tumor_normal.*")
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_FreqRQDMTumor.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/columncontain/ColumnsContainSameValueVariantCentric_FreqRQDMTumor.scala
@@ -1,0 +1,22 @@
+package bio.ferlab.clin.etl.qc.columncontain
+
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+import org.apache.spark.sql.functions._
+
+object ColumnsContainSameValueVariantCentric_FreqRQDMTumor extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    handleErrors(
+      shouldNotContainSameValue(
+        variant_centric.select($"freq_rqdm_tumor_only.*"),
+        variant_centric.select($"freq_rqdm_tumor_only.*").columns.filterNot(List("pn").contains(_)): _*
+      ),
+      shouldNotContainSameValue(
+        variant_centric.select($"freq_rqdm_tumor_normal.*"),
+        variant_centric.select($"freq_rqdm_tumor_normal.*").columns.filterNot(List("pn").contains(_)): _*
+      ),
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/frequency/RQDMTumorNormal.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/frequency/RQDMTumorNormal.scala
@@ -1,0 +1,33 @@
+package bio.ferlab.clin.etl.qc.frequency
+
+import org.apache.spark.sql.functions.lit
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+
+object RQDMTumorNormal extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    val df_normalized_snv_somatic_filter = normalized_snv_somatic
+    .where($"bioinfo_analysis_code" === "TNEBA")
+
+    val NbPatients = df_normalized_snv_somatic_filter
+    .groupBy($"sample_id").count
+    .count
+
+    val df_expected_Freq = df_normalized_snv_somatic_filter
+    .select($"chromosome", $"start", $"reference", $"alternate", $"patient_id", $"ad_alt", $"sq", $"filters", $"calls", $"analysis_code", $"affected_status_code")
+    .groupBy($"chromosome", $"start", $"reference", $"alternate")
+    .agg(pc_somatic)
+    .withColumn("expected_pn", lit(NbPatients))
+
+    handleErrors(
+      shouldBeEmpty(
+        variant_centric
+        .select($"chromosome", $"start", $"reference", $"alternate", $"freq_rqdm_tumor_normal.*")
+        .join(df_expected_Freq, Seq("chromosome", "start", "reference", "alternate"), "inner")
+        .filter(!($"expected_pc" <=> $"pc") || !($"expected_pn" <=> $"pn"))
+      )
+    )
+  }
+}

--- a/src/main/scala/bio/ferlab/clin/etl/qc/frequency/RQDMTumorOnly.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/qc/frequency/RQDMTumorOnly.scala
@@ -1,0 +1,33 @@
+package bio.ferlab.clin.etl.qc.frequency
+
+import org.apache.spark.sql.functions.lit
+import bio.ferlab.clin.etl.qc.TestingApp
+import bio.ferlab.clin.etl.qc.TestingApp._
+
+object RQDMTumorOnly extends TestingApp {
+  run { spark =>
+    import spark.implicits._
+
+    val df_normalized_snv_somatic_filter = normalized_snv_somatic
+    .where($"bioinfo_analysis_code" === "TEBA")
+
+    val NbPatients = df_normalized_snv_somatic_filter
+    .groupBy($"sample_id").count
+    .count
+
+    val df_expected_Freq = df_normalized_snv_somatic_filter
+    .select($"chromosome", $"start", $"reference", $"alternate", $"patient_id", $"ad_alt", $"sq", $"filters", $"calls", $"analysis_code", $"affected_status_code")
+    .groupBy($"chromosome", $"start", $"reference", $"alternate")
+    .agg(pc_somatic)
+    .withColumn("expected_pn", lit(NbPatients))
+
+    handleErrors(
+      shouldBeEmpty(
+        variant_centric
+        .select($"chromosome", $"start", $"reference", $"alternate", $"freq_rqdm_tumor_only.*")
+        .join(df_expected_Freq, Seq("chromosome", "start", "reference", "alternate"), "inner")
+        .filter(!($"expected_pc" <=> $"pc") || !($"expected_pn" <=> $"pn"))
+      )
+    )
+  }
+}


### PR DESCRIPTION
# FEAT : Add freq RQDM tumor DataTests

- complements #CLIN-2938

## Description

[CLIN-2938](https://ferlab-crsj.atlassian.net/browse/CLIN-2938)

[CLIN-2938]: https://ferlab-crsj.atlassian.net/browse/CLIN-2938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ